### PR TITLE
feat: main page basic layout setup

### DIFF
--- a/packages/dashboard/src/app/page.tsx
+++ b/packages/dashboard/src/app/page.tsx
@@ -1,7 +1,13 @@
+import Content from "@/components/Content";
+import Navbar from "@/components/Navbar";
+import SearchInput from "@/components/SearchInput";
+
 export default function Home() {
   return (
     <main className="flex flex-col items-center min-h-screen px-24 py-4">
-      <h2 className="text-2xl font-bold text-gray-800">Dashboard</h2>
+      <Navbar />
+      <SearchInput />
+      <Content />
     </main>
   );
 }

--- a/packages/dashboard/src/components/Content.tsx
+++ b/packages/dashboard/src/components/Content.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+
+// Mock components for placeholder content
+const MockBlockData: React.FC = () => (
+    <div className="flex-1 mr-4 bg-gray-200 p-4 rounded-lg shadow-lg">
+        <h2 className="text-xl font-bold text-gray-800 mb-4">Latest Block Data</h2>
+        <p>Block Number: 12345</p>
+        <p>Timestamp: {new Date().toLocaleString()}</p>
+        <p>Miner: 0xABC123</p>
+    </div>
+);
+
+const MockTransactions: React.FC = () => (
+    <div className="flex-1 bg-gray-200 p-4 rounded-lg shadow-lg">
+        <h2 className="text-xl font-bold text-gray-800 mb-4">Latest Transactions</h2>
+        <ul>
+            <li>Transaction 1</li>
+            <li>Transaction 2</li>
+            <li>Transaction 3</li>
+        </ul>
+    </div>
+);
+
+const Content: React.FC = () => {
+    return (
+        <section className="flex flex-1 justify-between w-full">
+            <MockBlockData />
+            <MockTransactions />
+        </section>
+    );
+};
+
+export default Content;

--- a/packages/dashboard/src/components/Navbar.tsx
+++ b/packages/dashboard/src/components/Navbar.tsx
@@ -1,0 +1,20 @@
+"use client"
+
+import Link from "next/link"
+import { ConnectButton } from "@rainbow-me/rainbowkit"
+import { Button } from "./ui/button"
+
+const Navbar: React.FC = () => {
+    return (
+        <section className="flex justify-between w-full">
+            <Link href="/">
+                <h2 className="text-2xl font-bold text-gray-800">Dashboard</h2>
+            </Link>
+            <ConnectButton.Custom>
+                {({ openConnectModal }) => <Button onClick={openConnectModal}>Sign In</Button>}
+            </ConnectButton.Custom>
+
+        </section>
+    )
+}
+export default Navbar

--- a/packages/dashboard/src/components/SearchInput.tsx
+++ b/packages/dashboard/src/components/SearchInput.tsx
@@ -1,0 +1,12 @@
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+
+const SearchInput: React.FC = () => {
+  return (
+    <div className="flex w-full max-w-sm items-center space-x-2 my-12">
+      <Input type="text" placeholder="Block Number"/>
+      <Button type="submit">Search</Button>
+    </div>
+  )
+}
+export default SearchInput;

--- a/packages/dashboard/src/components/ui/input.tsx
+++ b/packages/dashboard/src/components/ui/input.tsx
@@ -1,0 +1,25 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+export interface InputProps
+  extends React.InputHTMLAttributes<HTMLInputElement> {}
+
+const Input = React.forwardRef<HTMLInputElement, InputProps>(
+  ({ className, type, ...props }, ref) => {
+    return (
+      <input
+        type={type}
+        className={cn(
+          "flex h-10 w-full rounded-md border border-slate-200 bg-white px-3 py-2 text-sm ring-offset-white file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-slate-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-950 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 dark:border-slate-800 dark:bg-slate-950 dark:ring-offset-slate-950 dark:placeholder:text-slate-400 dark:focus-visible:ring-slate-300",
+          className
+        )}
+        ref={ref}
+        {...props}
+      />
+    )
+  }
+)
+Input.displayName = "Input"
+
+export { Input }


### PR DESCRIPTION
Established the initial structure for the main page with the following components:
- Displayed a heading "Dashboard" using a text element
- Integrated a Navbar component for navigation (for now added only connect button)
- Included a SearchInput component for user interaction (functionality missing)
- Integrated the Content component to display main content (functionality missing)